### PR TITLE
Set travis to use stack and HEAD versions of cloud haskell dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,24 @@
-language: haskell
+language: c
 
-ghc:
- - 7.8
- - 7.6
- - 7.4
+sudo: false
+
+matrix:
+  include:
+    - env: CABALVER=1.22 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
 
 before_install:
-  - cabal sandbox init
-  - for i in `cat REPOS`; do git clone http://github.com/haskell-distributed/$i; done
-  - for i in `cat REPOS`; do cabal sandbox add-source $i; done
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq binutils-dev
+  - mkdir -p ~/.local/bin
+  - export PATH=~/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar -xzO --wildcards '*/stack' > ~/.local/bin/stack
+  - chmod a+x ~/.local/bin/stack
 
 install:
-  # Don't run tests for dependencies.
-  - cabal install --only-dependencies
-  - cabal install --only-dependencies distributed-process-tests
+  - stack -j 2 setup --no-terminal
+  - stack -j 2 build --only-snapshot --no-terminal
 
 script:
-  - cabal install
-  - cabal install --enable-tests -j1 distributed-process-tests
+  - stack -j 2 test --no-terminal
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,17 @@
+resolver: nightly-2016-03-02
+packages:
+- .
+- location:
+    git: https://github.com/haskell-distributed/distributed-static.git
+    commit: HEAD
+- location:
+    git: https://github.com/haskell-distributed/rank1dynamic.git
+    commit: HEAD
+- location:
+    git: https://github.com/haskell-distributed/distributed-process.git
+    commit: HEAD
+
+extra-deps:
+- network-transport-tcp-0.4.2
+- rematch-0.2.0.0
+


### PR DESCRIPTION
Maybe merge this before #5, and rebase with master? That way we'll get travis to confirm that #5 is good to merge.
