### PR TITLE
Make concurrent utilities exception safe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
   include:
     - env: CABALVER=1.22 GHCVER=7.8.4
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2],sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
 
 before_install:
   - mkdir -p ~/.local/bin

--- a/distributed-process-extras.cabal
+++ b/distributed-process-extras.cabal
@@ -39,6 +39,7 @@ library
                    time > 1.4 && < 1.6,
                    transformers >= 0.2 && < 0.5
   extensions:      CPP
+  other-extensions: ExistentialQuantification
   ghc-options:      -Wall
   HS-Source-Dirs:    src
   exposed-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,4 +11,5 @@ extra-deps:
 - distributed-process-0.6.1
 - network-transport-tcp-0.5.1
 - rematch-0.2.0.0
+- distributed-process-0.6.1
 


### PR DESCRIPTION
Usage of old distributed-process exception handling API
is not safe in presence of exceptions. We switch to using
exceptions based exception handlers and remove typeclasses
by switching to data structures for locks.
