### PR TITLE
adjustments to compile with GHC 8.0.1

### DIFF
--- a/distributed-process-extras.cabal
+++ b/distributed-process-extras.cabal
@@ -27,7 +27,7 @@ library
   build-depends:   base >= 4.4 && < 5,
                    data-accessor >= 0.2.2.3,
                    distributed-process >= 0.6.1 && < 0.7,
-                   binary >= 0.6.3.0 && < 0.8,
+                   binary >= 0.6.3.0 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,
                    mtl >= 2.0 && < 2.4,
                    containers >= 0.4 && < 0.6,
@@ -37,7 +37,7 @@ library
                    fingertree < 0.2,
                    stm >= 2.4 && < 2.5,
                    time > 1.4 && < 1.6,
-                   transformers >= 0.2 && < 0.5
+                   transformers >= 0.2 && < 0.6
   extensions:      CPP
   other-extensions: ExistentialQuantification
   ghc-options:      -Wall
@@ -94,7 +94,7 @@ test-suite PrimitivesTests
                    mtl,
                    containers >= 0.4 && < 0.6,
                    network-transport-tcp >= 0.4 && < 0.6,
-                   binary >= 0.6.3.0 && < 0.8,
+                   binary >= 0.6.3.0 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,
                    network >= 2.3 && < 2.7,
                    HUnit >= 1.2 && < 2,
@@ -155,7 +155,7 @@ test-suite LoggerTests
                    deepseq >= 1.3.0.1 && < 1.6,
                    mtl,
                    network-transport-tcp >= 0.4 && < 0.6,
-                   binary >= 0.6.3.0 && < 0.8,
+                   binary >= 0.6.3.0 && < 0.9,
                    network >= 2.3 && < 2.7,
                    HUnit >= 1.2 && < 2,
                    stm >= 2.3 && < 2.5,

--- a/src/Control/Distributed/Process/Extras/SystemLog.hs
+++ b/src/Control/Distributed/Process/Extras/SystemLog.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
I am unable to run the tests due to distributed-haskell-systest missing from hackage. It would help if the expected test workflow were documented.

This patch includes zero code changes.