### PR TITLE
Tighten lower bound on base

### DIFF
--- a/distributed-process-extras.cabal
+++ b/distributed-process-extras.cabal
@@ -30,7 +30,7 @@ flag old-locale
   default: False
 
 library
-  build-depends:   base >= 4.6 && < 5,
+  build-depends:   base >= 4.8 && < 5,
                    distributed-process >= 0.6.6 && < 0.7,
                    binary >= 0.6.3.0 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,


### PR DESCRIPTION
Currently this package can't be compiled with pre-AMP `base`s (see compile failure below for GHC 7.8.4).
And as this package is only CI-tested with GHC 7.10 & GHC 8.0, it seems like the intent is rather to support only `base >= 4.8`.

```
Configuring component lib from distributed-process-extras-0.3.2...
Preprocessing library distributed-process-extras-0.3.2...
[ 1 of 14] Compiling Control.Distributed.Process.Extras.Internal.Unsafe ( src/Control/Distributed/Process/Extras/Internal/Unsafe.hs, /tmp/matrix-worker/1490789727/dist-newstyle/build/x86_64-linux/ghc-7.8.4/distributed-process-extras-0.3.2/build/Control/Distributed/Process/Extras/Internal/Unsafe.o )
[ 2 of 14] Compiling Control.Distributed.Process.Extras.Internal.Queue.PriorityQ ( src/Control/Distributed/Process/Extras/Internal/Queue/PriorityQ.hs, /tmp/matrix-worker/1490789727/dist-newstyle/build/x86_64-linux/ghc-7.8.4/distributed-process-extras-0.3.2/build/Control/Distributed/Process/Extras/Internal/Queue/PriorityQ.o )
[ 3 of 14] Compiling Control.Distributed.Process.Extras.Internal.Queue.SeqQ ( src/Control/Distributed/Process/Extras/Internal/Queue/SeqQ.hs, /tmp/matrix-worker/1490789727/dist-newstyle/build/x86_64-linux/ghc-7.8.4/distributed-process-extras-0.3.2/build/Control/Distributed/Process/Extras/Internal/Queue/SeqQ.o )
[ 4 of 14] Compiling Control.Distributed.Process.Extras.Internal.Containers.MultiMap ( src/Control/Distributed/Process/Extras/Internal/Containers/MultiMap.hs, /tmp/matrix-worker/1490789727/dist-newstyle/build/x86_64-linux/ghc-7.8.4/distributed-process-extras-0.3.2/build/Control/Distributed/Process/Extras/Internal/Containers/MultiMap.o )

src/Control/Distributed/Process/Extras/Internal/Containers/MultiMap.hs:28:1: Warning:
    The import of ‘Data.Foldable’ is redundant
      except perhaps to import instances from ‘Data.Foldable’
    To import instances alone, use: import Data.Foldable()
[ 5 of 14] Compiling Control.Concurrent.Utils ( src/Control/Concurrent/Utils.hs, /tmp/matrix-worker/1490789727/dist-newstyle/build/x86_64-linux/ghc-7.8.4/distributed-process-extras-0.3.2/build/Control/Concurrent/Utils.o )

src/Control/Concurrent/Utils.hs:32:24: Not in scope: ‘<$>’

src/Control/Concurrent/Utils.hs:32:39: Not in scope: ‘<*>’

src/Control/Concurrent/Utils.hs:32:43: Not in scope: ‘pure’

src/Control/Concurrent/Utils.hs:32:57: Not in scope: ‘<*>’

src/Control/Concurrent/Utils.hs:32:61: Not in scope: ‘pure’

src/Control/Concurrent/Utils.hs:36:18: Not in scope: ‘<$>’

src/Control/Concurrent/Utils.hs:36:32: Not in scope: ‘<*>’

src/Control/Concurrent/Utils.hs:36:36: Not in scope: ‘pure’

src/Control/Concurrent/Utils.hs:36:50: Not in scope: ‘<*>’

src/Control/Concurrent/Utils.hs:36:54: Not in scope: ‘pure’
```