### PR TITLE
Update upper bounds

### DIFF
--- a/distributed-process-extras.cabal
+++ b/distributed-process-extras.cabal
@@ -30,7 +30,7 @@ flag old-locale
 
 library
   build-depends:   base >= 4.8 && < 5,
-                   distributed-process >= 0.7,
+                   distributed-process >= 0.6.0 && < 0.8,
                    binary >= 0.6.3.0 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,
                    mtl >= 2.0 && < 2.4,
@@ -71,7 +71,7 @@ test-suite InternalQueueTests
   build-depends:
                    base >= 4.6 && < 5,
                    ansi-terminal >= 0.5 && < 0.9,
-                   distributed-process >= 0.7,
+                   distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
                    distributed-process-systest >= 0.1.0 && < 0.3.0,
                    HUnit >= 1.2 && < 2,
@@ -94,7 +94,7 @@ test-suite PrimitivesTests
   build-depends:
                    base >= 4.6 && < 5,
                    ansi-terminal >= 0.5 && < 0.9,
-                   distributed-process >= 0.7,
+                   distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
                    distributed-process-systest >= 0.1.0 && < 0.3.0,
                    network-transport >= 0.4 && < 0.6,
@@ -123,7 +123,7 @@ test-suite TimerTests
                    base >= 4.6 && < 5,
                    ansi-terminal >= 0.5 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,
-                   distributed-process >= 0.7,
+                   distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
                    distributed-process-systest >= 0.1.0 && < 0.3.0,
                    network-transport >= 0.4 && < 0.6,
@@ -151,7 +151,7 @@ test-suite LoggerTests
                    containers,
                    hashable,
                    unordered-containers >= 0.2.3.0 && < 0.3,
-                   distributed-process >= 0.7,
+                   distributed-process >= 0.6.0 && < 0.8,
                    distributed-process-extras,
                    distributed-process-systest >= 0.1.0 && < 0.3.0,
                    distributed-static,

--- a/distributed-process-extras.cabal
+++ b/distributed-process-extras.cabal
@@ -1,5 +1,5 @@
 name:           distributed-process-extras
-version:        0.3.3.1
+version:        0.3.4
 cabal-version:  >=1.8
 build-type:     Simple
 license:        BSD3
@@ -8,7 +8,6 @@ stability:      experimental
 Copyright:      Tim Watson 2012 - 2017
 Author:         Tim Watson
 Maintainer:     Tim Watson <watson.timothy@gmail.com>
-Stability:      experimental
 Homepage:       http://github.com/haskell-distributed/distributed-process-extras
 Bug-Reports:    http://github.com/haskell-distributed/distributed-process-extras/issues
 synopsis:       Cloud Haskell Extras
@@ -31,7 +30,7 @@ flag old-locale
 
 library
   build-depends:   base >= 4.8 && < 5,
-                   distributed-process >= 0.6.6 && < 0.7,
+                   distributed-process >= 0.7,
                    binary >= 0.6.3.0 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,
                    mtl >= 2.0 && < 2.4,
@@ -71,10 +70,10 @@ test-suite InternalQueueTests
   x-uses-tf:       true
   build-depends:
                    base >= 4.6 && < 5,
-                   ansi-terminal >= 0.5 && < 0.7,
-                   distributed-process >= 0.6.6 && < 0.7,
+                   ansi-terminal >= 0.5 && < 0.9,
+                   distributed-process >= 0.7,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.2.0,
+                   distributed-process-systest >= 0.1.0 && < 0.3.0,
                    HUnit >= 1.2 && < 2,
                    test-framework >= 0.6 && < 0.9,
                    test-framework-hunit,
@@ -94,11 +93,11 @@ test-suite PrimitivesTests
   x-uses-tf:       true
   build-depends:
                    base >= 4.6 && < 5,
-                   ansi-terminal >= 0.5 && < 0.7,
-                   distributed-process >= 0.6.6 && < 0.7,
+                   ansi-terminal >= 0.5 && < 0.9,
+                   distributed-process >= 0.7,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.2.0,
-                   network-transport >= 0.4 && < 0.5,
+                   distributed-process-systest >= 0.1.0 && < 0.3.0,
+                   network-transport >= 0.4 && < 0.6,
                    mtl,
                    containers >= 0.4 && < 0.6,
                    network-transport-tcp >= 0.4 && < 0.6,
@@ -122,12 +121,12 @@ test-suite TimerTests
   x-uses-tf:       true
   build-depends:
                    base >= 4.6 && < 5,
-                   ansi-terminal >= 0.5 && < 0.7,
+                   ansi-terminal >= 0.5 && < 0.9,
                    deepseq >= 1.3.0.1 && < 1.6,
-                   distributed-process >= 0.6.6 && < 0.7,
+                   distributed-process >= 0.7,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.2.0,
-                   network-transport >= 0.4 && < 0.5,
+                   distributed-process-systest >= 0.1.0 && < 0.3.0,
+                   network-transport >= 0.4 && < 0.6,
                    network-transport-tcp >= 0.4 && < 0.6,
                    HUnit >= 1.2 && < 2,
                    test-framework >= 0.6 && < 0.9,
@@ -148,18 +147,18 @@ test-suite LoggerTests
 --  x-uses-tf:       true
   build-depends:
                    base >= 4.6 && < 5,
-                   ansi-terminal >= 0.5 && < 0.7,
+                   ansi-terminal >= 0.5 && < 0.9,
                    containers,
                    hashable,
                    unordered-containers >= 0.2.3.0 && < 0.3,
-                   distributed-process >= 0.6.6 && < 0.7,
+                   distributed-process >= 0.7,
                    distributed-process-extras,
-                   distributed-process-systest >= 0.1.0 && < 0.2.0,
+                   distributed-process-systest >= 0.1.0 && < 0.3.0,
                    distributed-static,
                    bytestring,
                    data-accessor,
                    fingertree < 0.2,
-                   network-transport >= 0.4 && < 0.5,
+                   network-transport >= 0.4 && < 0.6,
                    deepseq >= 1.3.0.1 && < 1.6,
                    mtl,
                    network-transport-tcp >= 0.4 && < 0.6,

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,6 @@ packages:
 
 extra-deps:
 - network-transport-inmemory-0.5.1  # snapshot 0.5.2 in lts-7.18
-- distributed-process-0.6.6         # missing snapshot
-- distributed-process-systest-0.1.1 # missing prior to Jan-2017
+- distributed-process-0.7.3         # missing snapshot
 - rematch-0.2.0.0
+- distributed-process-systest-0.2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,4 +7,3 @@ extra-deps:
 - network-transport-inmemory-0.5.1  # snapshot 0.5.2 in lts-7.18
 - distributed-process-0.7.3         # missing snapshot
 - rematch-0.2.0.0
-- distributed-process-systest-0.2.0


### PR DESCRIPTION
Update upper bounds to work with `distributed-process` suite on latest version of Haskell libraries.